### PR TITLE
Add pre-1.0 tensorflow to requirements.txt.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+tensorflow==0.12.1


### PR DESCRIPTION
I ran the following with Python 2.7, tensorflow 1.x:

```
$ python nvdm.py --data_dir data/20news                                                                              
```

It produced this error:

```
Traceback (most recent call last):
  File "nvdm.py", line 227, in <module>
    tf.app.run()
  File "/home/cjmay/.local/lib/python2.7/site-packages/tensorflow/python/platform/app.py", line 48, in run
    _sys.exit(main(_sys.argv[:1] + flags_passthrough))
  File "nvdm.py", line 216, in main
    non_linearity=non_linearity)
  File "nvdm.py", line 62, in __init__
    doc_vec = tf.mul(tf.exp(self.logsigm), eps) + self.mean
AttributeError: 'module' object has no attribute 'mul'
```

Some Googling indicated tf.mul was renamed to tf.multiply.  Pinning the tensorflow version to 0.12.1 fixes the bug.  A requirements.txt file seems like a good way to preserve and convey that restraint?